### PR TITLE
Kiểm tra file hình chèn vào có tồn tại hay không

### DIFF
--- a/codes/rules/abs-link.js
+++ b/codes/rules/abs-link.js
@@ -1,0 +1,1 @@
+module.exports = /^(https?|file|ftps?|mailto|javascript|data:image\/[^;]{2,9};):/i 

--- a/codes/rules/check-external-links.js
+++ b/codes/rules/check-external-links.js
@@ -1,0 +1,23 @@
+const visit = require("unist-util-visit")
+
+const absLink = /^(https?|file|ftps?|mailto|javascript|data:image\/[^;]{2,9};):/i
+
+function checkExternalLinks(ast, file, preferred, done) {
+  visit(ast, "image", (node) => {
+    const url = node.url
+
+    if (absLink.test(url)) {
+
+    }
+    // file.warn(
+    //   "Local images link must be ended with",
+    //   node
+    // )
+  })
+
+  done()
+}
+
+module.exports = {
+  "check-external-links": checkExternalLinks,
+}

--- a/codes/rules/check-image-ref.js
+++ b/codes/rules/check-image-ref.js
@@ -1,0 +1,49 @@
+const visit = require("unist-util-visit")
+const absLink = require("./abs-link")
+
+const path = require("path")
+const join = path.join
+const fs = require("pify")(require("fs"))
+
+function checkImageRef(ast, file, preferred, done) {
+  const promises = []
+
+  visit(ast, "image", (node) => {
+    const url = node.url
+    // Get full folder path
+    const folderPath = join(
+      __dirname,
+      "../../",
+      file.filePath().split("/").slice(0, -1).join("/"),
+      "/"
+    )
+
+    if (!absLink.test(url)) {
+      const fileName = url.split("/").pop()
+      const fullPath = join(folderPath, fileName)
+      promises.push(
+        fs
+        .access(fullPath, fs.R_OK)
+        .catch(() => {
+          process.nextTick(() => {
+            file.warn(`Image doesn't exits "${ url }"`, node)
+          })
+        })
+      )
+    }
+  })
+
+  Promise.all(promises)
+  .then(() => {
+    done()
+  })
+  .catch((err) => {
+    process.nextTick(() => {
+      throw err
+    })
+  })
+}
+
+module.exports = {
+  "check-image-ref": checkImageRef,
+}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   "homepage": "https://github.com/daynhauhoc/cppcoban#readme",
   "devDependencies": {
     "remark": "^4.2.1",
-    "remark-lint": "^3.2.0"
+    "remark-lint": "^3.2.0",
+    "unist-util-visit": "^1.1.0"
   },
   "remarkConfig": {
     "commonmark": true,
@@ -24,7 +25,8 @@
         "list-item-bullet-indent": false,
         "list-item-spacing": false,
         "first-heading-level": 2,
-        "no-html": false
+        "no-html": false,
+        "external": ["./codes/rules/check-image-ref.js"]
       }
     }
   }


### PR DESCRIPTION
Hôm qua @dinhquochan gửi cái PR chứa hình nhưng mà có 1 tấm bị sai tên file.

Bằng mắt thường thì rất khó để phát hiện ra lỗi này. Nên em đã làm 1 cái rule để nó check luôn trong quá trình lint markdown.

Chưa biết ảnh hưởng của cái rule này lên tốc độ lint như thế nào vì mình chỉ mới có < 10 hình.

Benchmark với 10000 hình thì nó mất thêm 5giây để check. Em nghĩ vậy là okie rồi.

@trandatnh  anh nghĩ còn rule nào mình nên thêm vào ?

![image](https://cloud.githubusercontent.com/assets/3049054/14584410/a70af7a0-046f-11e6-89dc-9c082cf83099.png)
